### PR TITLE
chore: configuring Jfrog OIDC

### DIFF
--- a/.github/workflows/java-app.yml
+++ b/.github/workflows/java-app.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
+          JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
           oidc-provider-name: gc-secure-artifacts
 

--- a/.github/workflows/java-app.yml
+++ b/.github/workflows/java-app.yml
@@ -36,6 +36,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
           oidc-audience: https://github.com/gccloudone
@@ -85,6 +86,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
           oidc-audience: https://github.com/gccloudone
@@ -118,6 +120,7 @@ jobs:
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
           JF_INCLUDE_ALL_VULNERABILITIES: "true"

--- a/.github/workflows/java-app.yml
+++ b/.github/workflows/java-app.yml
@@ -20,6 +20,7 @@ jobs:
   build-and-scan:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
       security-events: write
       pull-requests: write
@@ -31,17 +32,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
-      - name: Docker login
-        run: |
-          echo "${{ secrets.JFROG_JWT_TOKEN }}" | docker login ${{ env.REGISTRY }} \
-            --username "${{ secrets.JFROG_USERNAME }}" --password-stdin
+      - name: Docker login via OIDC
+        run: jf docker-login ${{ env.REGISTRY }}
 
       - name: Scan Dependencies for Vulnerabilities
         run: |
@@ -60,6 +60,7 @@ jobs:
         run: |
           IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.dockerfile }}
           docker push $IMAGE_TAG
+
       - name: Publish Build Info
         run: |
           jf rt build-add-git ${{ matrix.dockerfile }}-app ${{ github.run_number }}
@@ -76,15 +77,17 @@ jobs:
     if: github.event_name == 'push'
     needs: [build-and-scan]
     permissions:
+      id-token: write
       contents: read
 
     steps:
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -102,6 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       security-events: write
@@ -110,21 +114,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Frogbot
+      - name: Run Frogbot with OIDC
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
           JF_INCLUDE_ALL_VULNERABILITIES: "true"
           JF_ENABLE_SAST: "true"
           JF_ENABLE_SECRETS: "true"
           JF_ENABLE_IAC: "true"
+          JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
+          JF_OIDC_AUDIENCE: https://github.com/gccloudone
+
   summary:
     needs: [build-and-scan, cleanup]
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'push'
+    permissions:
+      contents: read
 
     steps:
       - name: Build Summary
@@ -139,3 +147,4 @@ jobs:
           echo "- Automated Cleanup: Checked for old images to save storage costs" >> $GITHUB_STEP_SUMMARY
           echo "- Frogbot: Automated security comments on pull requests" >> $GITHUB_STEP_SUMMARY
           echo "- Image Scanning: JFrog Xray scanned container images" >> $GITHUB_STEP_SUMMARY
+          echo "- OIDC Authentication: Secure credential-less authentication" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/java-app.yml
+++ b/.github/workflows/java-app.yml
@@ -116,7 +116,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Frogbot with OIDC
+      - name: Setup JFrog CLI with OIDC
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
+
+      - name: Run Frogbot
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
@@ -127,8 +136,6 @@ jobs:
           JF_ENABLE_SAST: "true"
           JF_ENABLE_SECRETS: "true"
           JF_ENABLE_IAC: "true"
-          JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
-          JF_OIDC_AUDIENCE: https://github.com/gccloudone
 
   summary:
     needs: [build-and-scan, cleanup]

--- a/.github/workflows/java-app.yml
+++ b/.github/workflows/java-app.yml
@@ -39,7 +39,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Docker login via OIDC
         run: jf docker-login ${{ env.REGISTRY }}
@@ -89,7 +88,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -123,7 +121,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Run Frogbot
         uses: jfrog/frogbot@v2

--- a/.github/workflows/java-app.yml
+++ b/.github/workflows/java-app.yml
@@ -39,7 +39,7 @@ jobs:
           JF_PROJECT: ssc-aurora
           JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Docker login via OIDC
         run: jf docker-login ${{ env.REGISTRY }}
@@ -88,7 +88,7 @@ jobs:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -121,7 +121,7 @@ jobs:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Run Frogbot
         uses: jfrog/frogbot@v2

--- a/.github/workflows/node-app.yml
+++ b/.github/workflows/node-app.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "examples/node-app/**"
       - ".github/workflows/**"
+
 env:
   REGISTRY: artifacts-artefacts.devops.cloud-nuage.canada.ca
   IMAGE_NAME: ssc-aurora-docker-local/node-app
@@ -19,6 +20,7 @@ jobs:
   build-and-scan:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
       security-events: write
       pull-requests: write
@@ -30,17 +32,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
-      - name: Docker login
-        run: |
-          echo "${{ secrets.JFROG_JWT_TOKEN }}" | docker login ${{ env.REGISTRY }} \
-            --username "${{ secrets.JFROG_USERNAME }}" --password-stdin
+      - name: Docker login via OIDC
+        run: jf docker-login ${{ env.REGISTRY }}
 
       - name: Scan Dependencies for Vulnerabilities
         run: |
@@ -59,10 +60,12 @@ jobs:
         run: |
           IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.dockerfile }}
           docker push $IMAGE_TAG
+
       - name: Publish Build Info
         run: |
           jf rt build-add-git ${{ matrix.dockerfile }}-app ${{ github.run_number }}
           jf rt build-publish ${{ matrix.dockerfile }}-app ${{ github.run_number }}
+
       - name: Scan with JFrog Xray
         run: |
           IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.dockerfile }}
@@ -74,15 +77,17 @@ jobs:
     if: github.event_name == 'push'
     needs: [build-and-scan]
     permissions:
+      id-token: write
       contents: read
 
     steps:
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -100,6 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       security-events: write
@@ -108,22 +114,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Frogbot
+      - name: Run Frogbot with OIDC
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
           JF_INCLUDE_ALL_VULNERABILITIES: "true"
           JF_ENABLE_SAST: "true"
           JF_ENABLE_SECRETS: "true"
           JF_ENABLE_IAC: "true"
+          JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
+          JF_OIDC_AUDIENCE: https://github.com/gccloudone
 
   summary:
     needs: [build-and-scan, cleanup]
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'push'
+    permissions:
+      contents: read
 
     steps:
       - name: Build Summary
@@ -138,3 +147,4 @@ jobs:
           echo "- Automated Cleanup: Checked for old images to save storage costs" >> $GITHUB_STEP_SUMMARY
           echo "- Frogbot: Automated security comments on pull requests" >> $GITHUB_STEP_SUMMARY
           echo "- Image Scanning: JFrog Xray scanned container images" >> $GITHUB_STEP_SUMMARY
+          echo "- OIDC Authentication: Secure credential-less authentication" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/node-app.yml
+++ b/.github/workflows/node-app.yml
@@ -36,6 +36,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
           oidc-audience: https://github.com/gccloudone
@@ -85,6 +86,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
           oidc-audience: https://github.com/gccloudone
@@ -118,6 +120,7 @@ jobs:
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
           JF_INCLUDE_ALL_VULNERABILITIES: "true"

--- a/.github/workflows/node-app.yml
+++ b/.github/workflows/node-app.yml
@@ -38,7 +38,7 @@ jobs:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Docker login via OIDC
         run: jf docker-login ${{ env.REGISTRY }}
@@ -87,7 +87,7 @@ jobs:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -121,7 +121,7 @@ jobs:
           JF_PROJECT: ssc-aurora
           JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Run Frogbot
         uses: jfrog/frogbot@v2

--- a/.github/workflows/node-app.yml
+++ b/.github/workflows/node-app.yml
@@ -119,6 +119,7 @@ jobs:
         env:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
+          JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
           oidc-provider-name: gc-secure-artifacts
 

--- a/.github/workflows/node-app.yml
+++ b/.github/workflows/node-app.yml
@@ -39,7 +39,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Docker login via OIDC
         run: jf docker-login ${{ env.REGISTRY }}
@@ -89,7 +88,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -116,7 +114,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Frogbot with OIDC
+      - name: Setup JFrog CLI with OIDC
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
+        with:
+          oidc-provider-name: gc-secure-artifacts
+
+      - name: Run Frogbot
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
@@ -127,8 +133,6 @@ jobs:
           JF_ENABLE_SAST: "true"
           JF_ENABLE_SECRETS: "true"
           JF_ENABLE_IAC: "true"
-          JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
-          JF_OIDC_AUDIENCE: https://github.com/gccloudone
 
   summary:
     needs: [build-and-scan, cleanup]

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,6 +36,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
           oidc-audience: https://github.com/gccloudone
@@ -85,6 +86,7 @@ jobs:
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
           oidc-audience: https://github.com/gccloudone
@@ -118,6 +120,7 @@ jobs:
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
           JF_INCLUDE_ALL_VULNERABILITIES: "true"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,7 +39,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Docker login via OIDC
         run: jf docker-login ${{ env.REGISTRY }}
@@ -89,7 +88,6 @@ jobs:
           JF_PROJECT: ssc-aurora
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Cleanup Old Images (Cost Savings)
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,7 +38,7 @@ jobs:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Docker login via OIDC
         run: jf docker-login ${{ env.REGISTRY }}
@@ -88,7 +88,7 @@ jobs:
           JF_PROJECT: ssc-aurora
           JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -122,7 +122,7 @@ jobs:
           JF_PROJECT: ssc-aurora
           JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Run Frogbot
         uses: jfrog/frogbot@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "examples/python-app/**"
       - ".github/workflows/**"
+
 env:
   REGISTRY: artifacts-artefacts.devops.cloud-nuage.canada.ca
   IMAGE_NAME: ssc-aurora-docker-local/python-app
@@ -19,6 +20,7 @@ jobs:
   build-and-scan:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
       security-events: write
       pull-requests: write
@@ -30,17 +32,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
-      - name: Docker login
-        run: |
-          echo "${{ secrets.JFROG_JWT_TOKEN }}" | docker login ${{ env.REGISTRY }} \
-            --username "${{ secrets.JFROG_USERNAME }}" --password-stdin
+      - name: Docker login via OIDC
+        run: jf docker-login ${{ env.REGISTRY }}
 
       - name: Scan Dependencies for Vulnerabilities
         run: |
@@ -59,10 +60,12 @@ jobs:
         run: |
           IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.dockerfile }}
           docker push $IMAGE_TAG
+
       - name: Publish Build Info
         run: |
           jf rt build-add-git ${{ matrix.dockerfile }}-app ${{ github.run_number }}
           jf rt build-publish ${{ matrix.dockerfile }}-app ${{ github.run_number }}
+
       - name: Scan with JFrog Xray
         run: |
           IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.dockerfile }}
@@ -74,15 +77,17 @@ jobs:
     if: github.event_name == 'push'
     needs: [build-and-scan]
     permissions:
+      id-token: write
       contents: read
 
     steps:
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
       - name: Cleanup Old Images (Cost Savings)
         run: |
@@ -100,6 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       security-events: write
@@ -108,22 +114,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Frogbot
+      - name: Run Frogbot with OIDC
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
           JF_INCLUDE_ALL_VULNERABILITIES: "true"
           JF_ENABLE_SAST: "true"
           JF_ENABLE_SECRETS: "true"
           JF_ENABLE_IAC: "true"
+          JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
+          JF_OIDC_AUDIENCE: https://github.com/gccloudone
 
   summary:
     needs: [build-and-scan, cleanup]
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'push'
+    permissions:
+      contents: read
 
     steps:
       - name: Build Summary
@@ -138,3 +147,4 @@ jobs:
           echo "- Automated Cleanup: Checked for old images to save storage costs" >> $GITHUB_STEP_SUMMARY
           echo "- Frogbot: Automated security comments on pull requests" >> $GITHUB_STEP_SUMMARY
           echo "- Image Scanning: JFrog Xray scanned container images" >> $GITHUB_STEP_SUMMARY
+          echo "- OIDC Authentication: Secure credential-less authentication" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -86,6 +86,7 @@ jobs:
         env:
           JF_URL: https://${{ env.REGISTRY }}
           JF_PROJECT: ssc-aurora
+          JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
         with:
           oidc-provider-name: gc-secure-artifacts
 
@@ -114,7 +115,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Frogbot with OIDC
+      - name: Setup JFrog CLI with OIDC
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://${{ env.REGISTRY }}
+          JF_PROJECT: ssc-aurora
+          JFROG_CLI_AVOID_NEW_VERSION_WARNING: "true"
+        with:
+          oidc-provider-name: gc-secure-artifacts
+
+      - name: Run Frogbot
         uses: jfrog/frogbot@v2
         env:
           JF_URL: https://${{ env.REGISTRY }}
@@ -125,8 +135,6 @@ jobs:
           JF_ENABLE_SAST: "true"
           JF_ENABLE_SECRETS: "true"
           JF_ENABLE_IAC: "true"
-          JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
-          JF_OIDC_AUDIENCE: https://github.com/gccloudone
 
   summary:
     needs: [build-and-scan, cleanup]

--- a/.github/workflows/update-chainguard-digests.yml
+++ b/.github/workflows/update-chainguard-digests.yml
@@ -9,23 +9,23 @@ jobs:
   update-digests:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JFrog CLI
+      - name: Setup JFrog CLI with OIDC
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+        with:
+          oidc-provider-name: gc-secure-artifacts
+          oidc-audience: https://github.com/gccloudone
 
-      - name: Docker login
-        run: |
-          echo "${{ secrets.JFROG_JWT_TOKEN }}" | docker login artifacts-artefacts.devops.cloud-nuage.canada.ca \
-            --username "${{ secrets.JFROG_USERNAME }}" --password-stdin
+      - name: Docker login via OIDC
+        run: jf docker-login artifacts-artefacts.devops.cloud-nuage.canada.ca
 
       - name: Get latest digests
         run: |

--- a/.github/workflows/update-chainguard-digests.yml
+++ b/.github/workflows/update-chainguard-digests.yml
@@ -22,7 +22,6 @@ jobs:
           JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
         with:
           oidc-provider-name: gc-secure-artifacts
-          oidc-audience: https://github.com/gccloudone
 
       - name: Docker login via OIDC
         run: jf docker-login artifacts-artefacts.devops.cloud-nuage.canada.ca

--- a/.github/workflows/update-chainguard-digests.yml
+++ b/.github/workflows/update-chainguard-digests.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
         with:
-          oidc-provider-name: gc-secure-artifacts
+          oidc-provider-name: github-oidc
 
       - name: Docker login via OIDC
         run: jf docker-login artifacts-artefacts.devops.cloud-nuage.canada.ca

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,11 +3,52 @@
 ## Prerequisites
 
 1. **JFrog Access**: Ensure you have GC Secure Artifacts access
-2. **Repository Secrets**: Configure these in your GitHub repository:
-   - `JFROG_USERNAME`: Your Artifactory username
-   - `JFROG_JWT_TOKEN`: Your Artifactory access token
+2. **OIDC Configuration**: Your repository must be configured in JFrog's OIDC identity mappings (see below)
+3. **No Secrets Required**: OIDC eliminates the need for stored credentials
 
-## Step 1: Update Your Dockerfile
+### Configure Identity Mappings in JFrog
+
+Before using the workflows, set up OIDC authentication in JFrog Artifactory:
+
+1. Login to [JFrog Artifactory](https://artifacts-artefacts.devops.cloud-nuage.canada.ca)
+2. Click **Administration** (gear icon) → **Platform Security** → **OpenID Connect** → **Identity Mappings** tab
+3. Click **+ New Identity Mapping** and create mappings for each workflow:
+
+**For your repository workflows, create these identity mappings:**
+
+```
+Name: your-org-java-app
+Priority: 1
+Description: OIDC mapping for Java application workflow
+
+Claims JSON:
+{
+    "iss": "https://token.actions.githubusercontent.com",
+    "repository": "your-org/your-repo",
+    "workflow_ref": "your-org/your-repo/.github/workflows/java-app.yml@refs/heads/main"
+}
+
+Token Scope: (leave blank)
+Roles: Viewer
+Service: artifactory
+Token Expiration: 10 minutes
+```
+
+*Replace `your-org/your-repo` with your actual GitHub organization and repository name. Create similar mappings for python-app.yml, node-app.yml, and any other workflows you use.*
+
+## Step 1: Add OIDC Permissions
+
+Add these permissions to your workflow jobs:
+
+```yaml
+permissions:
+  id-token: write  authentication
+  contents: read
+  security-events: write
+  pull-requests: write
+```
+
+## Step 2: Update Your Dockerfile
 
 Replace your current base image with a Chainguard equivalent:
 
@@ -21,18 +62,22 @@ FROM python:3.13-slim
 FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:3.13.3
 ```
 
-## Step 2: Add JFrog CLI to Your Workflow
+## Step 3: Setup JFrog CLI with OIDC
 
 ```yaml
-- name: Setup JFrog CLI
+- name: Setup JFrog CLI with OIDC
   uses: jfrog/setup-jfrog-cli@v4
   env:
     JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
-    JF_USER: ${{ secrets.JFROG_USERNAME }}
-    JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+  with:
+    oidc-provider-name: gc-secure-artifacts
+    oidc-audience: https://github.com/gccloudone
+
+- name: Docker login via OIDC
+  run: jf docker-login artifacts-artefacts.devops.cloud-nuage.canada.ca
 ```
 
-## Step 3: Add Security Scanning
+## Step 4: Add Security Scanning
 
 **Scan Dependencies:**
 ```yaml
@@ -52,7 +97,7 @@ FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/s
     jf docker scan $IMAGE_TAG
 ```
 
-## Step 4: Enable Frogbot for Pull Requests
+## Step 5: Enable Frogbot for Pull Requests
 
 Add this job to your workflow:
 
@@ -61,6 +106,7 @@ frogbot:
   runs-on: ubuntu-latest
   if: github.event_name == 'pull_request' || github.event_name == 'push'
   permissions:
+    id-token: write
     contents: read
     pull-requests: write
     security-events: write
@@ -69,12 +115,13 @@ frogbot:
   - uses: jfrog/frogbot@v2
     env:
       JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
-      JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
       JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JF_GIT_USE_GITHUB_ENVIRONMENT: "false"
+      JF_OIDC_PROVIDER_NAME: gc-secure-artifacts
+      JF_OIDC_AUDIENCE: https://github.com/gccloudone
 ```
 
-## Step 5: Add Cost Management
+## Step 6: Add Cost Management
 
 Include automated cleanup analysis:
 
@@ -83,13 +130,17 @@ cleanup:
   runs-on: ubuntu-latest
   if: github.event_name == 'push'
   needs: [build-and-scan]
+  permissions:
+    id-token: write
+    contents: read
   steps:
-  - name: Setup JFrog CLI
+  - name: Setup JFrog CLI with OIDC
     uses: jfrog/setup-jfrog-cli@v4
     env:
       JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
-      JF_USER: ${{ secrets.JFROG_USERNAME }}
-      JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+    with:
+      oidc-provider-name: gc-secure-artifacts
+      oidc-audience: https://github.com/gccloudone
   - name: Cleanup Analysis
     run: |
       echo "Running automated cleanup to save storage costs..."
@@ -97,13 +148,11 @@ cleanup:
       echo "Found $CLEANUP_COUNT old images that could be cleaned up"
 ```
 
-## Step 6: Push to JFrog Registry
+## Step 7: Push to JFrog Registry
 
 ```yaml
-- name: Docker login
-  run: |
-    echo "${{ secrets.JFROG_JWT_TOKEN }}" | docker login artifacts-artefacts.devops.cloud-nuage.canada.ca \
-      --username "${{ secrets.JFROG_USERNAME }}" --password-stdin
+- name: Docker login via OIDC
+  run: jf docker-login artifacts-artefacts.devops.cloud-nuage.canada.ca
 
 - name: Build and push
   run: |
@@ -149,16 +198,18 @@ jobs:
   update-digests:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     steps:
     - uses: actions/checkout@v4
-    - name: Setup JFrog CLI
+    - name: Setup JFrog CLI with OIDC
       uses: jfrog/setup-jfrog-cli@v4
       env:
         JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
-        JF_USER: ${{ secrets.JFROG_USERNAME }}
-        JF_ACCESS_TOKEN: ${{ secrets.JFROG_JWT_TOKEN }}
+      with:
+        oidc-provider-name: gc-secure-artifacts
+        oidc-audience: https://github.com/gccloudone
     # Automatically updates Dockerfiles with latest secure digests
 ```
 
@@ -239,6 +290,7 @@ JFrog Developer Tools Used:
 - Automated Cleanup: Checked for old images to save storage costs
 - Frogbot: Automated security comments on pull requests
 - Image Scanning: JFrog Xray scanned container images
+- OIDC Authentication: Secure credential-less authentication
 ```
 
 ## Common Commands
@@ -285,6 +337,14 @@ steps:
 ```
 
 *Note: Matrix strategy is demonstrated in this repository but optional for your implementation.*
+
+## OIDC Security Benefits
+
+- **Enhanced Security**: No long-lived credentials stored in GitHub
+- **Reduced Management**: No secret rotation required
+- **Better Audit Trail**: Clear identity mapping in JFrog logs
+- **Principle of Least Privilege**: Workflow-specific permissions
+- **Compliance**: Meets modern security standards for CI/CD
 
 ## Support
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,7 +70,7 @@ FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/s
   env:
     JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
   with:
-    oidc-provider-name: gc-secure-artifacts
+    oidc-provider-name: github-oidc
 
 
 - name: Docker login via OIDC
@@ -139,7 +139,7 @@ cleanup:
     env:
       JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
     with:
-      oidc-provider-name: gc-secure-artifacts
+      oidc-provider-name: github-oidc
 
   - name: Cleanup Analysis
     run: |
@@ -208,7 +208,7 @@ jobs:
       env:
         JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
       with:
-        oidc-provider-name: gc-secure-artifacts
+        oidc-provider-name: github-oidc
 
     # Automatically updates Dockerfiles with latest secure digests
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/s
     JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
   with:
     oidc-provider-name: gc-secure-artifacts
-    oidc-audience: https://github.com/gccloudone
+
 
 - name: Docker login via OIDC
   run: jf docker-login artifacts-artefacts.devops.cloud-nuage.canada.ca
@@ -140,7 +140,7 @@ cleanup:
       JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
     with:
       oidc-provider-name: gc-secure-artifacts
-      oidc-audience: https://github.com/gccloudone
+
   - name: Cleanup Analysis
     run: |
       echo "Running automated cleanup to save storage costs..."
@@ -209,7 +209,7 @@ jobs:
         JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
       with:
         oidc-provider-name: gc-secure-artifacts
-        oidc-audience: https://github.com/gccloudone
+
     # Automatically updates Dockerfiles with latest secure digests
 ```
 


### PR DESCRIPTION
# Migrate to OIDC Authentication for Enhanced Security

## Summary
This pull request migrates all GitHub Actions workflows from secret-based authentication to OpenID Connect (OIDC) for secure, credential-less access to JFrog Artifactory.

## What Changed

### Security Improvements
- **Removed stored secrets**: Eliminated `JFROG_USERNAME` and `JFROG_JWT_TOKEN` from repository secrets
- **Added OIDC authentication**: Implemented workflow-specific identity mappings
- **Enhanced permissions**: Added `id-token: write` to all jobs requiring JFrog access
- **Token expiration**: Limited authentication tokens to 10 minutes maximum

### Files Modified
- `.github/workflows/java-app.yml` - Updated Java workflow with OIDC
- `.github/workflows/python-app.yml` - Updated Python workflow with OIDC  
- `.github/workflows/node-app.yml` - Updated Node.js workflow with OIDC
- `.github/workflows/update-chainguard-digests.yml` - Updated digest update workflow with OIDC
- `docs/quickstart.md` - Added OIDC configuration documentation

### Technical Changes
- **JFrog CLI Setup**: Replaced secret-based auth with OIDC provider configuration
- **Docker Login**: Changed from credential-based to `jf docker-login` command
- **Frogbot Configuration**: Updated to use OIDC environment variables
- **Permissions**: Added `id-token: write` to all relevant workflow jobs

Thanks to @kingbain for Jfrog OIDC